### PR TITLE
Bug Fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2025-01-31  DoccY <alban.mancheron@lirmm.fr>
+
+	* include/fstream.h:
+	Ensure previous stream is closed before opening a new one.
+	Clear stream status before trying to close it.
+	
+	
 2025-01-30  DoccY <alban.mancheron@lirmm.fr>
 
 	* include/bzstream.h:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2025-01-30  DoccY <alban.mancheron@lirmm.fr>
+
+	* include/bzstream.h:
+	API Change: Now the `bz::streambuf::tellg()` method returns the (virtual) position of the uncompressed stream.
+	BugFix: The `bz::streambuf::seekg()` method was wrong.
+	
+	
 2025-01-29  DoccY <alban.mancheron@lirmm.fr>
 
 	* include/bzstream.h, include/fstream.h, include/gzstream.h:

--- a/include/fstream.h
+++ b/include/fstream.h
@@ -47,12 +47,14 @@ public:
 
     void open(const char* name, int open_mode)
     {
+        close();
         if (!buf.open(name, open_mode))
             clear(rdstate() | std::ios::badbit);
     }
 
     void close()
     {
+        clear();
         if (buf.is_open())
             if (!buf.close())
                 clear(rdstate() | std::ios::badbit);


### PR DESCRIPTION
Hello,

As mentioned in the previous request, I did some changes in the API in order to return the the (virtual) position of the uncompressed stream when  the `bz::streambuf::tellg()` method is invoked (this allow to invoke `seekg()` with a coherent value.
I also rewrite my preceding version of `bz::streambuf::seekg()` method which was completely wrong.

In the end, I also modify the `compression::fstream::open()` method to ensure that the previous stream is closed before opening a new one and the `compression::fstream::close()` method to clear the stream status before trying to close it.

I hope you'll find some interest in these modifications.
Sincerely,
Alban Mancheron